### PR TITLE
Add aria-labels to buttons below US map

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,10 @@
             <img class="map" style="width:50%; display:block; margin: 0 auto;" src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Map_of_USA_States_with_names_white.svg/981px-Map_of_USA_States_with_names_white.svg.png" alt="Map of the United States"/>
             <p class="text-md-center">Gigillo83, original of 70.29.208.129, CC BY-SA 4.0 <https://creativecommons.org/licenses/by-sa/4.0>, via Wikimedia Commons</p>
             <div class="btn-group d-flex justify-content-center" role="group" aria-label="Basic outlined example">
-                <a href="https://codeforamerica.org/wp-content/uploads/2022/02/2022-getyourrefund-outreach-partnerships-guide-code-for-america.pdf" target="_blank" class="btn btn-outline-primary">Outreach Guide</a>
-                <a href="#" target="_blank" class="btn btn-outline-primary">Sample Messages</a>
-                <a href="https://files.codeforamerica.org/2022/01/07161314/lessons-from-simplified-filing-in-2021-getctc-report-january-2022.pdf" target="_blank" class="btn btn-outline-primary">More About Tax Benefits and Outreach</a>
-                <a href="#" target="_blank" class="btn btn-outline-primary">Contact Us</a>
+                <a href="https://codeforamerica.org/wp-content/uploads/2022/02/2022-getyourrefund-outreach-partnerships-guide-code-for-america.pdf" aria-label="Outreach Guide" target="_blank" class="btn btn-outline-primary">Outreach Guide</a>
+                <a href="#" target="_blank" class="btn btn-outline-primary" aria-label="Sample Messages">Sample Messages</a>
+                <a href="https://files.codeforamerica.org/2022/01/07161314/lessons-from-simplified-filing-in-2021-getctc-report-january-2022.pdf" target="_blank" aria-label="More About Tax Benefits and Outreach" class="btn btn-outline-primary">More About Tax Benefits and Outreach</a>
+                <a href="#" target="_blank" class="btn btn-outline-primary" aria-label="Contact Us">Contact Us</a>
             </div>
 
 


### PR DESCRIPTION
Added aria-labels to describe the purpose of the a tags on the lower
portion of the website. This should improve the accessibility of these
elements. Reference issue #10  